### PR TITLE
Add filter for transcoded video and thumbnail name changes

### DIFF
--- a/admin/rt-transcoder-handler.php
+++ b/admin/rt-transcoder-handler.php
@@ -778,7 +778,7 @@ class RT_Transcoder_Handler {
 		$failed_thumbnails      = false;
 
 		foreach ( $post_thumbs_array['thumbnail'] as $thumbnail ) {
-			$thumbresource         = function_exists( 'vip_safe_wp_remote_get' ) ? vip_safe_wp_remote_get( $thumbnail, array( 'timeout' => 3000 ) ) : wp_remote_get( $thumbnail, array( 'timeout' => 3000 ) );  // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.wp_remote_get_wp_remote_get, WordPressVIPMinimum.Performance.RemoteRequestTimeout.timeout_timeout
+			$thumbresource         = function_exists( 'vip_safe_wp_remote_get' ) ? vip_safe_wp_remote_get( $thumbnail, '', 3, 3 ) : wp_remote_get( $thumbnail, array( 'timeout' => 30 ) );  // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.wp_remote_get_wp_remote_get, WordPressVIPMinimum.Performance.RemoteRequestTimeout.timeout_timeout
 			$thumbinfo             = pathinfo( $thumbnail );
 			$temp_name             = $thumbinfo['basename'];
 			$temp_name             = urldecode( $temp_name );
@@ -935,8 +935,15 @@ class RT_Transcoder_Handler {
 							$new_wp_attached_file_pathinfo = pathinfo( $download_url );
 							$post_mime_type                = 'mp4' === $new_wp_attached_file_pathinfo['extension'] ? 'video/mp4' : 'audio/mp3';
 							$attachemnt_url                = wp_get_attachment_url( $attachment_id );
+
+							$timeout = 5;
+
+							if ( 'video/mp4' === $post_mime_type ) {
+								$timeout = 30;
+							}
+
 							try {
-								$response = function_exists( 'vip_safe_wp_remote_get' ) ? vip_safe_wp_remote_get( $download_url, '', 3, 3 ) : wp_remote_get( $download_url ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.wp_remote_get_wp_remote_get
+								$response = function_exists( 'vip_safe_wp_remote_get' ) ? vip_safe_wp_remote_get( $download_url, '', 3, 3 ) : wp_remote_get( $download_url, array( 'timeout' => $timeout ) ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.wp_remote_get_wp_remote_get
 							} catch ( Exception $e ) {
 								$flag = $e->getMessage();
 							}
@@ -1028,6 +1035,7 @@ class RT_Transcoder_Handler {
 							} else {
 								$uploads = wp_upload_dir();
 							}
+
 							if ( 'video/mp4' === $post_mime_type ) {
 								$media_type = 'mp4';
 							} elseif ( 'audio/mp3' === $post_mime_type ) {

--- a/admin/rt-transcoder-handler.php
+++ b/admin/rt-transcoder-handler.php
@@ -782,8 +782,23 @@ class RT_Transcoder_Handler {
 			$temp_name             = $thumbinfo['basename'];
 			$temp_name             = urldecode( $temp_name );
 			$temp_name_array       = explode( '/', $temp_name );
-			$temp_name             = $temp_name_array[ count( $temp_name_array ) - 1 ];
-			$thumbinfo['basename'] = apply_filters( 'transcoded_temp_filename', $temp_name );
+			$thumbinfo['basename'] = $temp_name_array[ count( $temp_name_array ) - 1 ];
+
+			/**
+			 * Filter: 'transcoded_temp_filename' - Allows changes for the thumbnail name.
+			 *
+			 * @deprecated 1.3.2. Use the {@see 'transcoded_thumb_filename'} filter instead.
+			 */
+			$thumbinfo['basename'] = apply_filters_deprecated( 'transcoded_temp_filename', array( $thumbinfo['basename'] ), '1.3.2', 'transcoded_thumb_filename' );
+
+			/**
+			 * Allows users/plugins to filter the thumbnail Name
+			 *
+			 * @since 1.3.2
+			 *
+			 * @param string $temp_name Contains the thumbnail public name
+			 */
+			$thumbinfo['basename'] = apply_filters( 'transcoded_thumb_filename', $thumbinfo['basename'] );
 
 			if ( 'wp-media' !== $post_thumbs_array['job_for'] ) {
 				add_filter( 'upload_dir', array( $this, 'upload_dir' ) );
@@ -920,7 +935,15 @@ class RT_Transcoder_Handler {
 									add_filter( 'upload_dir', array( $this, 'upload_dir' ) );
 								}
 
-								$upload_info = wp_upload_bits( $new_wp_attached_file_pathinfo['basename'], null, $file_content );
+								/**
+								 * Allows users/plugins to filter the transcoded file Name
+								 *
+								 * @since 1.0.5
+								 *
+								 * @param string $new_wp_attached_file_pathinfo['basename']  Contains the file public name
+								 */
+								$video_url   = apply_filters( 'transcoded_video_filename', $new_wp_attached_file_pathinfo['basename'] );
+								$upload_info = wp_upload_bits( $video_url, null, $file_content );
 
 								/**
 								 * Allow users to filter/perform action on uploaded transcoded file.

--- a/admin/rt-transcoder-handler.php
+++ b/admin/rt-transcoder-handler.php
@@ -799,7 +799,7 @@ class RT_Transcoder_Handler {
 			 *
 			 * @param string $temp_name Contains the thumbnail public name
 			 */
-			$thumbinfo['basename'] = apply_filters( 'transcoded_thumb_filename', $thumbinfo['basename'], $post_array );
+			$thumbinfo['basename'] = apply_filters( 'transcoded_thumb_filename', $thumbinfo['basename'] );
 
 			// Verify Extension.
 			if ( empty( pathinfo( $thumbinfo['basename'], PATHINFO_EXTENSION ) ) ) {

--- a/admin/rt-transcoder-handler.php
+++ b/admin/rt-transcoder-handler.php
@@ -778,7 +778,7 @@ class RT_Transcoder_Handler {
 		$failed_thumbnails      = false;
 
 		foreach ( $post_thumbs_array['thumbnail'] as $thumbnail ) {
-			$thumbresource         = function_exists( 'vip_safe_wp_remote_get' ) ? vip_safe_wp_remote_get( $thumbnail, [ 'timeout' => 3000 ] ) : wp_remote_get( $thumbnail, [ 'timeout' => 3000 ] );  // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.wp_remote_get_wp_remote_get
+			$thumbresource         = function_exists( 'vip_safe_wp_remote_get' ) ? vip_safe_wp_remote_get( $thumbnail, array( 'timeout' => 3000 ) ) : wp_remote_get( $thumbnail, array( 'timeout' => 3000 ) );  // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.wp_remote_get_wp_remote_get, WordPressVIPMinimum.Performance.RemoteRequestTimeout.timeout_timeout
 			$thumbinfo             = pathinfo( $thumbnail );
 			$temp_name             = $thumbinfo['basename'];
 			$temp_name             = urldecode( $temp_name );

--- a/admin/rt-transcoder-handler.php
+++ b/admin/rt-transcoder-handler.php
@@ -778,7 +778,7 @@ class RT_Transcoder_Handler {
 		$failed_thumbnails      = false;
 
 		foreach ( $post_thumbs_array['thumbnail'] as $thumbnail ) {
-			$thumbresource         = function_exists( 'vip_safe_wp_remote_get' ) ? vip_safe_wp_remote_get( $thumbnail, '', 3, 3 ) : wp_remote_get( $thumbnail, array( 'timeout' => 30 ) );  // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.wp_remote_get_wp_remote_get, WordPressVIPMinimum.Performance.RemoteRequestTimeout.timeout_timeout
+			$thumbresource         = function_exists( 'vip_safe_wp_remote_get' ) ? vip_safe_wp_remote_get( $thumbnail, '', 3, 3 ) : wp_remote_get( $thumbnail, array( 'timeout' => 120 ) );  // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.wp_remote_get_wp_remote_get, WordPressVIPMinimum.Performance.RemoteRequestTimeout.timeout_timeout
 			$thumbinfo             = pathinfo( $thumbnail );
 			$temp_name             = $thumbinfo['basename'];
 			$temp_name             = urldecode( $temp_name );
@@ -939,7 +939,7 @@ class RT_Transcoder_Handler {
 							$timeout = 5;
 
 							if ( 'video/mp4' === $post_mime_type ) {
-								$timeout = 30;
+								$timeout = 120;
 							}
 
 							try {

--- a/admin/rt-transcoder-handler.php
+++ b/admin/rt-transcoder-handler.php
@@ -789,7 +789,7 @@ class RT_Transcoder_Handler {
 			 *
 			 * @deprecated 1.3.2. Use the {@see 'transcoded_thumb_filename'} filter instead.
 			 */
-			$thumbinfo['basename'] = apply_filters_deprecated( 'transcoded_temp_filename', array( $thumbinfo['basename'] ), '1.3.2', 'transcoded_thumb_filename' );
+			$thumbinfo['basename'] = apply_filters_deprecated( 'transcoded_temp_filename', array( $thumbinfo['basename'] ), '1.3.2', 'transcoded_thumb_filename', __( 'Use transcoded_thumb_filename filter to modify video thumbnail name and transcoded_video_filename filter to modify video file name.', 'transcoder' ) );
 
 			/**
 			 * Allows users/plugins to filter the thumbnail Name


### PR DESCRIPTION
Related #218 

Adds 2 filters for thumbnail name and Video name
- `transcoded_video_filename` 
- `transcoded_thumb_filename`

This PR also deprecates old filter `transcoded_temp_filename` 