### PR TITLE
Remove extra spaces in the link syntax under Contributor and License Section

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ Transcoding services for ANY WordPress website. Convert audio/video files of any
  <img src="https://rtmedia.io/wp-content/uploads/2016/08/trancoder-banner-01.png" alt="Transcoder Banner"/>
 </p>
 
-* **Contributors:** [rtcamp] (http://profiles.wordpress.org/rtcamp), [mangeshp] (http://profiles.wordpress.org/mangeshp), [chandrapatel] (http://profiles.wordpress.org/chandrapatel), [manishsongirkar36] (http://profiles.wordpress.org/manishsongirkar36), [bhargavbhandari90] (http://profiles.wordpress.org/bhargavbhandari90), [kiranpotphode] (http://profiles.wordpress.org/kiranpotphode), [thrijith] (http://profiles.wordpress.org/thrijith), [devikvekariya] (http://profiles.wordpress.org/devikvekariya), [sagarnasit] (http://profiles.wordpress.org/sagarnasit), [sudhiryadav] (http://profiles.wordpress.org/sudhiryadav), [sid177] (https://profiles.wordpress.org/sid177/), [pooja1210] (https://profiles.wordpress.org/pooja1210/), [vaishu.agola27] (https://profiles.wordpress.org/vaishuagola27/), [ravatparmar] (https://profiles.wordpress.org/ravatparmar/)
+* **Contributors:** [rtcamp](http://profiles.wordpress.org/rtcamp), [mangeshp](http://profiles.wordpress.org/mangeshp), [chandrapatel](http://profiles.wordpress.org/chandrapatel), [manishsongirkar36](http://profiles.wordpress.org/manishsongirkar36), [bhargavbhandari90](http://profiles.wordpress.org/bhargavbhandari90), [kiranpotphode](http://profiles.wordpress.org/kiranpotphode), [thrijith](http://profiles.wordpress.org/thrijith), [devikvekariya](http://profiles.wordpress.org/devikvekariya), [sagarnasit](http://profiles.wordpress.org/sagarnasit), [sudhiryadav](http://profiles.wordpress.org/sudhiryadav), [sid177](https://profiles.wordpress.org/sid177/), [pooja1210](https://profiles.wordpress.org/pooja1210/), [vaishu.agola27](https://profiles.wordpress.org/vaishuagola27/), [ravatparmar](https://profiles.wordpress.org/ravatparmar/)
 
-* **License:** [GPL v2 or later] ( http://www.gnu.org/licenses/gpl-2.0.html)
+* **License:** [GPL v2 or later]( http://www.gnu.org/licenses/gpl-2.0.html)
 
 ## Description ##
 Transcoder easily converts all audio and video files uploaded to your website to a web-friendly format.


### PR DESCRIPTION
This PR will fix the Markdown link syntax in the Contributors and the License Section

## Before
![image](https://user-images.githubusercontent.com/14808994/111267755-68e1c980-8652-11eb-9439-9fca015cb0cc.png)

## After
![image](https://user-images.githubusercontent.com/14808994/111267787-75662200-8652-11eb-93ed-3f0e018a7769.png)
