### PR TITLE
Fix redirection when saving license

### DIFF
--- a/admin/partials/rt-transcoder-admin-display.php
+++ b/admin/partials/rt-transcoder-admin-display.php
@@ -31,7 +31,7 @@ $current_page = transcoder_filter_input( INPUT_GET, 'page', FILTER_SANITIZE_STRI
 	<div class="transcoder-settings-boxes-wrapper">
 		<div id="transcoder-settings-boxes" class="transcoder-settings-boxes-container transcoder-setting-container">
 			<p>
-			<form method="get" action="<?php echo admin_url( 'admin.php' ); ?>">
+			<form method="get" action="<?php echo esc_attr( admin_url( 'admin.php' ) ); ?>">
 				<label for="new-api-key">
 					<?php esc_html_e( 'Enter License Key', 'transcoder' ); ?>
 				</label>

--- a/admin/partials/rt-transcoder-admin-display.php
+++ b/admin/partials/rt-transcoder-admin-display.php
@@ -31,7 +31,7 @@ $current_page = transcoder_filter_input( INPUT_GET, 'page', FILTER_SANITIZE_STRI
 	<div class="transcoder-settings-boxes-wrapper">
 		<div id="transcoder-settings-boxes" class="transcoder-settings-boxes-container transcoder-setting-container">
 			<p>
-			<form method="get" action="<?php echo esc_attr( admin_url( 'admin.php' ) ); ?>">
+			<form method="get" action="<?php echo esc_url( admin_url( 'admin.php' ) ); ?>">
 				<label for="new-api-key">
 					<?php esc_html_e( 'Enter License Key', 'transcoder' ); ?>
 				</label>

--- a/admin/partials/rt-transcoder-admin-display.php
+++ b/admin/partials/rt-transcoder-admin-display.php
@@ -31,7 +31,7 @@ $current_page = transcoder_filter_input( INPUT_GET, 'page', FILTER_SANITIZE_STRI
 	<div class="transcoder-settings-boxes-wrapper">
 		<div id="transcoder-settings-boxes" class="transcoder-settings-boxes-container transcoder-setting-container">
 			<p>
-			<form method="get" action="/wp-admin/admin.php">
+			<form method="get" action="<?php echo admin_url( 'admin.php' ); ?>">
 				<label for="new-api-key">
 					<?php esc_html_e( 'Enter License Key', 'transcoder' ); ?>
 				</label>


### PR DESCRIPTION
Resolve the redirection to the main site when saving license if WordPress is installed on the subdirectory

Fix: #234 