### PR TITLE
Fix php8 compatibility errors

### DIFF
--- a/admin/rt-retranscode-admin.php
+++ b/admin/rt-retranscode-admin.php
@@ -242,10 +242,9 @@ class RetranscodeMedia {
 	 * @return void
 	 */
 	public function bulk_action_handler() {
-
-		$action  = transcoder_filter_input( INPUT_REQUEST, 'action', FILTER_SANITIZE_STRING );
-		$action2 = transcoder_filter_input( INPUT_REQUEST, 'action2', FILTER_SANITIZE_STRING );
-		$media   = transcoder_filter_input( INPUT_REQUEST, 'media', FILTER_SANITIZE_NUMBER_INT, FILTER_REQUIRE_ARRAY );
+		$action  = transcoder_filter_input( INPUT_GET, 'action', FILTER_SANITIZE_STRING );
+		$action2 = transcoder_filter_input( INPUT_GET, 'action2', FILTER_SANITIZE_STRING );
+		$media   = transcoder_filter_input( INPUT_GET, 'media', FILTER_SANITIZE_NUMBER_INT, FILTER_REQUIRE_ARRAY );
 
 		if ( empty( $action ) || empty( $media ) || ! is_array( $media ) ||
 			( 'bulk_retranscode_media' !== $action && 'bulk_retranscode_media' !== $action2 )

--- a/inc/helpers/custom-functions.php
+++ b/inc/helpers/custom-functions.php
@@ -8,13 +8,12 @@
 /**
  * This method is an improved version of PHP's filter_input() and
  * works well on PHP CLI as well which PHP default method does not.
- * Also Provide support INPUT_REQUEST.
  *
  * Reference:
  * - https://bugs.php.net/bug.php?id=49184
  * - https://bugs.php.net/bug.php?id=54672
  *
- * @param int    $type          One of INPUT_GET, INPUT_POST, INPUT_REQUEST, INPUT_COOKIE, INPUT_SERVER, or INPUT_ENV.
+ * @param int    $type          One of INPUT_GET, INPUT_POST, INPUT_COOKIE, INPUT_SERVER, or INPUT_ENV.
  * @param string $variable_name Name of a variable to get.
  * @param int    $filter        The ID of the filter to apply.
  * @param mixed  $options       filter to apply.
@@ -23,21 +22,6 @@
  *               variable_name variable is not set.
  */
 function transcoder_filter_input( $type, $variable_name, $filter = FILTER_DEFAULT, $options = null ) {
-
-	/**
-	 * Provide support of INPUT_REQUEST
-	 *
-	 * Reference: https://bugs.php.net/bug.php?id=54672
-	 */
-	if ( INPUT_REQUEST === $type ) {
-		if ( isset( $_POST[ $variable_name ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
-			$type = INPUT_POST;
-		} elseif ( isset( $_GET[ $variable_name ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			$type = INPUT_GET;
-		} else {
-			return null;
-		}
-	}
 
 	if ( php_sapi_name() !== 'cli' ) {
 


### PR DESCRIPTION
For PHP v8 we are getting a fatal error for `INPUT_REQUEST`. Since this is removed from v8. So we need to change `INPUT_REQUEST` to `INPUT_POST` or `INPUT_GET` depending on the request. Here is the thread on wp.org https://wordpress.org/support/topic/transcoder-errors-in-php-8/