### PR TITLE
GH-139: [rt_media attachment_id=XX] short does not work [Develop]

### DIFF
--- a/admin/rt-transcoder-functions.php
+++ b/admin/rt-transcoder-functions.php
@@ -52,6 +52,7 @@ function rt_media_shortcode( $attrs, $content = '' ) {
 	}
 
 	$mime_type = explode( '/', $type );
+	$media_url = '';
 
 	if ( 'video' === $mime_type[0] ) {
 
@@ -80,6 +81,10 @@ function rt_media_shortcode( $attrs, $content = '' ) {
 		}
 
 		$content = do_shortcode( "[audio {$audio_shortcode_attributes}]" );
+
+	} elseif ( 'image' === $mime_type[0] ) {
+
+		$content = '<p>' . esc_html__( 'Image attachments are not handled by Transcoder plugin.', 'transcoder' ) . '</p>';
 
 	}
 


### PR DESCRIPTION
## Description

- This PR: 
    - adds a message to the `rt_media` shortcode when the image attachment ID is added in `attachment_id`.
    - Fixes the `Undefined variable: $media_url` by initializing `$media_url` with a default value(.i.e. `''`).

## Fixes/Covers
- #139 