### PR TITLE
GH-246/GH-247: Issue with transcoding the previously uploaded audio files [Develop]

### DIFF
--- a/admin/rt-retranscode-admin.php
+++ b/admin/rt-retranscode-admin.php
@@ -634,7 +634,7 @@ class RetranscodeMedia {
 			die( wp_json_encode( array( 'error' => sprintf( __( 'Sending Failed: %d is an invalid media ID/type.', 'transcoder' ), intval( $id ) ) ) ) );
 		}
 
-		if ( 'audio/mpeg' === $media->post_mime_type ) {
+		if ( 'audio/mpeg' === $media->post_mime_type && 'mp3' === pathinfo( $media->guid, PATHINFO_EXTENSION ) ) {
 			// translators: Placeholder is for Media Name and ID of media.
 			die( wp_json_encode( array( 'error' => sprintf( __( '&quot;%1$s&quot; (ID %2$s) is MP3 file already. No need to send for transcoding', 'transcoder' ), esc_html( get_the_title( $media->ID ) ), $media->ID ) ) ) );
 		}


### PR DESCRIPTION
## Description
- This PR updates conditional check for `mp3` files.

## Requirement
- The default `post_mime_type` for `.m4a` files is `audio/mpeg`(The same is for `.mp3` files), so our condition was failing.
<img width="1438" alt="Screenshot 2023-03-09 at 6 48 52 PM" src="https://user-images.githubusercontent.com/63953699/224035128-503f405d-6a64-438f-94a9-7f902de0e298.png">

- Whenever we transcode any audio file, file is converted to mp3 & attachment is updated in `wp_postmeta` but in `wp_posts`, we are still having `post_mime_type` of the old media file.
<img width="1552" alt="Screenshot 2023-03-16 at 3 58 38 PM" src="https://user-images.githubusercontent.com/63953699/225589447-068b9e0f-c659-4563-9a4f-774963288f17.png">
<img width="1552" alt="Screenshot 2023-03-16 at 4 00 33 PM" src="https://user-images.githubusercontent.com/63953699/225590799-b91b3352-3b18-400e-b246-d3c93560465f.png">

## Fixes/Covers
- #246 
- #247 