### PR TITLE
GH-250: Fixes `Retranscode Media` button for `m4a` file types [Master]

### DIFF
--- a/admin/rt-retranscode-admin.php
+++ b/admin/rt-retranscode-admin.php
@@ -175,7 +175,7 @@ class RetranscodeMedia {
 				'video/' !== substr( $post->post_mime_type, 0, 6 ) &&
 				'application/pdf' !== $post->post_mime_type
 			) ||
-			'audio/mpeg' === $post->post_mime_type ||
+			( 'audio/mpeg' === $post->post_mime_type && 'mp3' === pathinfo( $post->guid, PATHINFO_EXTENSION ) ) ||
 			! current_user_can( $this->capability )
 		) {
 			return $actions;


### PR DESCRIPTION
## Description
- This PR adds `'mp3' === pathinfo( $post->guid, PATHINFO_EXTENSION )` in conditional checks for displaying `Retranscode Media` button on `m4a` file types.

## Fixes/Covers
- https://github.com/rtCamp/transcoder/issues/250