### PR TITLE
Fix PHP deprecation errors for PHP@8.1

### DIFF
--- a/admin/rt-transcoder-handler.php
+++ b/admin/rt-transcoder-handler.php
@@ -319,7 +319,6 @@ class RT_Transcoder_Handler {
 		$thumb_count = apply_filters( 'rt_media_total_video_thumbnails', $thumb_count, $attachment_id );
 
 		return $thumb_count > 10 ? 10 : $thumb_count;
-
 	}
 
 	/**
@@ -489,8 +488,10 @@ class RT_Transcoder_Handler {
 			add_action( 'admin_notices', array( $this, 'public_host_needed_notice' ) );
 		}
 
-		$apikey = trim( transcoder_filter_input( INPUT_GET, 'apikey', FILTER_SANITIZE_STRING ) );
-		$page   = transcoder_filter_input( INPUT_GET, 'page', FILTER_SANITIZE_STRING );
+		$filtered_apikey = transcoder_filter_input( INPUT_GET, 'apikey', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
+		$apikey          = ! empty( $filtered_apikey ) ? trim( $filtered_apikey ) : '';
+
+		$page = transcoder_filter_input( INPUT_GET, 'page', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 
 		if ( ! empty( $apikey ) && is_admin() && ! empty( $page ) && ( 'rt-transcoder' === $page ) ) {
 			/* Do not activate transcoding service on localhost */
@@ -1332,14 +1333,12 @@ class RT_Transcoder_Handler {
 				$rtmedia_upload_prefix = 'groups/';
 				$id                    = $this->uploaded['context_id'];
 			}
-		} else {
-			if ( 'group' !== $rtmedia_interaction->context->type ) {
+		} elseif ( 'group' !== $rtmedia_interaction->context->type ) {
 				$rtmedia_upload_prefix = 'users/';
 				$id                    = $this->uploaded['media_author'];
-			} else {
-				$rtmedia_upload_prefix = 'groups/';
-				$id                    = $rtmedia_interaction->context->id;
-			}
+		} else {
+			$rtmedia_upload_prefix = 'groups/';
+			$id                    = $rtmedia_interaction->context->id;
 		}
 
 		if ( ! $id ) {
@@ -1366,9 +1365,13 @@ class RT_Transcoder_Handler {
 	 * @param  string  $message         Email message.
 	 * @param  boolean $include_admin   If true then send an email to admin also else not.
 	 */
-	public function send_notification( $email_ids = array(), $subject, $message, $include_admin = true ) {
+	public function send_notification( $email_ids, $subject, $message, $include_admin = true ) {
 		if ( defined( 'RT_TRANSCODER_NO_MAIL' ) ) {
 			return;
+		}
+
+		if ( ! is_array( $email_ids ) ) {
+			$email_ids = array();
 		}
 
 		if ( empty( $subject ) || empty( $message ) ) {
@@ -1629,7 +1632,6 @@ class RT_Transcoder_Handler {
 		}
 
 		$this->wp_media_transcoding( array( 'mime_type' => 'application/pdf' ), $post_id );
-
 	}
 
 	/**

--- a/inc/helpers/custom-functions.php
+++ b/inc/helpers/custom-functions.php
@@ -21,7 +21,7 @@
  * @return mixed Value of the requested variable on success, FALSE if the filter fails, or NULL if the
  *               variable_name variable is not set.
  */
-function transcoder_filter_input( $type, $variable_name, $filter = FILTER_DEFAULT, $options = null ) {
+function transcoder_filter_input( $type, $variable_name, $filter = FILTER_DEFAULT, $options = 0 ) {
 
 	if ( php_sapi_name() !== 'cli' ) {
 
@@ -118,5 +118,4 @@ function transcoder_filter_input( $type, $variable_name, $filter = FILTER_DEFAUL
 	// phpcs:enable WordPress.Security.NonceVerification.Recommended, WordPress.Security.NonceVerification.Missing, WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
 
 	return filter_var( $input, $filter );
-
 }


### PR DESCRIPTION
## Fix PHP deprecation errors for PHP@8.1

### Fixes done in this PR
- File: [custom-functions.php](https://github.com/rtCamp/transcoder/blob/69dd88ba049bb651b5e7b0fea45423cc7d71dd35/inc/helpers/custom-functions.php)
	- Change the `null` default value to `0` as the type is `array|int`.
- File: [rt-transcoder-handler.php](https://github.com/rtCamp/transcoder/blob/69dd88ba049bb651b5e7b0fea45423cc7d71dd35/admin/rt-transcoder-handler.php)
	- Change the `apikey` to string before passing to the `trim()` function because it gives an error if a parameter is not of type string.
	- Remove default arguments from the `send_notification` method because there should be no required arguments after default arguments in the method/function. Also added validation to convert it into an `Array`.
- Also few other changes have been made to fix the phpcs errors.

### Related Issues
- #275