### PR TITLE
Fix PHP@8.1 deprecation errors and enhance security checks

### DIFF
--- a/admin/partials/rt-transcoder-admin-display.php
+++ b/admin/partials/rt-transcoder-admin-display.php
@@ -8,7 +8,7 @@
  * @subpackage Transcoder/Admin/Partials
  */
 
-$current_page = transcoder_filter_input( INPUT_GET, 'page', FILTER_SANITIZE_STRING );
+$current_page = transcoder_filter_input( INPUT_GET, 'page', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 ?>
 <div class="wrap">
 	<h1 class="rtm-option-title">

--- a/admin/rt-retranscode-admin.php
+++ b/admin/rt-retranscode-admin.php
@@ -122,7 +122,6 @@ class RetranscodeMedia {
 			'rt-retranscoder',
 			array( $this, 'retranscode_interface' )
 		);
-
 	}
 
 	/**
@@ -230,7 +229,7 @@ class RetranscodeMedia {
 		?>
 		<script type="text/javascript">
 			jQuery(document).ready(function($){
-				$('select[name^="action"] option:last-child').before('<option value="bulk_retranscode_media"><?php echo esc_attr( __( 'Retranscode Media', 'transcoder' ) ); ?></option>');
+				$('select[name^="action"] option:last-child').before('<option value="bulk_retranscode_media"><?php esc_html_e( 'Retranscode Media', 'transcoder' ); ?></option>');
 			});
 		</script>
 		<?php
@@ -242,8 +241,8 @@ class RetranscodeMedia {
 	 * @return void
 	 */
 	public function bulk_action_handler() {
-		$action  = transcoder_filter_input( INPUT_GET, 'action', FILTER_SANITIZE_STRING );
-		$action2 = transcoder_filter_input( INPUT_GET, 'action2', FILTER_SANITIZE_STRING );
+		$action  = transcoder_filter_input( INPUT_GET, 'action', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
+		$action2 = transcoder_filter_input( INPUT_GET, 'action2', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 		$media   = transcoder_filter_input( INPUT_GET, 'media', FILTER_SANITIZE_NUMBER_INT, FILTER_REQUIRE_ARRAY );
 
 		if ( empty( $action ) || empty( $media ) || ! is_array( $media ) ||
@@ -300,7 +299,7 @@ class RetranscodeMedia {
 
 			// Create the list of image IDs.
 			$usage_info = get_site_option( 'rt-transcoding-usage' );
-			$ids        = transcoder_filter_input( INPUT_GET, 'ids', FILTER_SANITIZE_STRING );
+			$ids        = transcoder_filter_input( INPUT_GET, 'ids', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 			if ( ! empty( $ids ) ) {
 				$media = array_map( 'intval', explode( ',', trim( $ids, ',' ) ) );
 				$ids   = implode( ',', $media );
@@ -372,7 +371,7 @@ class RetranscodeMedia {
 									<table border=0>
 									?>
 										<tr>
-											<td><input type="submit" class="button button-primary button-small" value="<?php echo esc_html__( 'Proceed with retranscoding', 'transcoder' ); ?>"></td>
+											<td><input type="submit" class="button button-primary button-small" value="<?php esc_attr_e( 'Proceed with retranscoding', 'transcoder' ); ?>"></td>
 											<td></td>
 										</tr>
 									<?php
@@ -386,7 +385,7 @@ class RetranscodeMedia {
 									}
 									?>
 										<tr>
-											<td><input type="submit" class="button button-primary button-small" value="<?php esc_html_e( 'Proceed with retranscoding', 'transcoder' ); ?>" ></td>
+											<td><input type="submit" class="button button-primary button-small" value="<?php esc_attr_e( 'Proceed with retranscoding', 'transcoder' ); ?>" ></td>
 											<td></td>
 										</tr>
 									</table>
@@ -422,7 +421,7 @@ class RetranscodeMedia {
 		<div id="retranscodemedia-bar-percent" style="position:absolute;left:50%;top:50%;width:300px;margin-left:-150px;height:25px;margin-top:-9px;font-weight:bold;text-align:center;"></div>
 	</div>
 
-	<p><input type="button" class="button hide-if-no-js" name="retranscodemedia-stop" id="retranscodemedia-stop" value="<?php esc_html_e( 'Abort the Operation', 'transcoder' ); ?>" /></p>
+	<p><input type="button" class="button hide-if-no-js" name="retranscodemedia-stop" id="retranscodemedia-stop" value="<?php esc_attr_e( 'Abort the Operation', 'transcoder' ); ?>" /></p>
 
 	<h3 class="title"><?php esc_html_e( 'Debugging Information', 'transcoder' ); ?></h3>
 
@@ -594,7 +593,7 @@ class RetranscodeMedia {
 
 	<p><?php esc_html_e( 'To begin, just press the button below.', 'transcoder' ); ?></p>
 
-	<p><input type="submit" class="button hide-if-no-js button button-primary" name="rt-retranscoder" id="rt-retranscoder" value="<?php esc_html_e( 'Retranscode All Media', 'transcoder' ); ?>" /></p>
+	<p><input type="submit" class="button hide-if-no-js button button-primary" name="rt-retranscoder" id="rt-retranscoder" value="<?php esc_attr_e( 'Retranscode All Media', 'transcoder' ); ?>" /></p>
 
 	<noscript><p><em><?php esc_html_e( 'You must enable Javascript in order to proceed!', 'transcoder' ); ?></em></p></noscript>
 
@@ -717,10 +716,10 @@ class RetranscodeMedia {
 	/**
 	 * Helper function to escape quotes in strings for use in Javascript
 	 *
-	 * @param string $string String to escape quotes from.
+	 * @param string $str String to escape quotes from.
 	 */
-	public function esc_quotes( $string ) {
-		return str_replace( '"', '\"', $string );
+	public function esc_quotes( $str ) {
+		return str_replace( '"', '\"', $str );
 	}
 
 	/**
@@ -744,7 +743,7 @@ class RetranscodeMedia {
 	 * @param  number $media_id     Post ID of the media.
 	 * @param  array  $post_request Post request coming for the transcoder API.
 	 */
-	public function rtt_before_thumbnail_store( $media_id = '', $post_request = '' ) {
+	public function rtt_before_thumbnail_store( $media_id = '', $post_request = '' ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
 		if ( empty( $media_id ) ) {
 			return;
 		}
@@ -767,7 +766,6 @@ class RetranscodeMedia {
 			rtt_delete_transcoded_files( $previous_thumbs );
 		}
 		delete_post_meta( $media_id, '_rt_media_thumbnails' );
-
 	}
 
 	/**
@@ -776,7 +774,7 @@ class RetranscodeMedia {
 	 * @param  number $media_id     Post ID of the media.
 	 * @param  array  $transcoded_files Post request coming for the transcoder API.
 	 */
-	public function rtt_before_transcoded_media_store( $media_id = '', $transcoded_files = '' ) {
+	public function rtt_before_transcoded_media_store( $media_id = '', $transcoded_files = '' ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
 		if ( empty( $media_id ) ) {
 			return;
 		}
@@ -791,7 +789,6 @@ class RetranscodeMedia {
 			}
 		}
 		delete_post_meta( $media_id, '_rt_media_transcoded_files' );
-
 	}
 
 	/**
@@ -872,7 +869,7 @@ class RetranscodeMedia {
 	 * @param  number $attachment_id      Post ID of the media.
 	 * @param  string $job_id             Unique job ID of the transcoding request.
 	 */
-	public function rtt_handle_callback_finished( $attachment_id = '', $job_id = '' ) {
+	public function rtt_handle_callback_finished( $attachment_id = '', $job_id = '' ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
 		if ( empty( $attachment_id ) ) {
 			return;
 		}
@@ -884,7 +881,6 @@ class RetranscodeMedia {
 			delete_post_meta( $attachment_id, '_rt_retranscoding_sent' );
 
 		}
-
 	}
 
 	/**
@@ -1015,7 +1011,6 @@ class RetranscodeMedia {
 		$where .= " AND post_mime_type LIKE 'audio/%' OR post_mime_type LIKE 'video/%'";
 		return $where;
 	}
-
 }
 
 // Start up this plugin.
@@ -1024,7 +1019,7 @@ add_action( 'init', 'retranscode_media' );
 /**
  * Execute RetranscodeMedia constructor.
  */
-function retranscode_media() {
+function retranscode_media() { // phpcs:ignore Universal.Files.SeparateFunctionsFromOO.Mixed
 
 	global $RetranscodeMedia; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 

--- a/admin/rt-transcoder-admin.php
+++ b/admin/rt-transcoder-admin.php
@@ -185,7 +185,7 @@ class RT_Transcoder_Admin {
 	public function enqueue_scripts_styles() {
 		global $pagenow;
 
-		$page = transcoder_filter_input( INPUT_GET, 'page', FILTER_SANITIZE_STRING );
+		$page = transcoder_filter_input( INPUT_GET, 'page', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 
 		if ( 'admin.php' !== $pagenow || 'rt-transcoder' !== $page ) {
 			return;
@@ -377,7 +377,7 @@ class RT_Transcoder_Admin {
 	 */
 	public function save_video_thumbnail( $post ) {
 
-		$rtmedia_thumbnail = transcoder_filter_input( INPUT_POST, 'rtmedia-thumbnail', FILTER_SANITIZE_STRING );
+		$rtmedia_thumbnail = transcoder_filter_input( INPUT_POST, 'rtmedia-thumbnail', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 		$id                = ( ! empty( $post['ID'] ) && 0 < intval( $post['ID'] ) ) ? intval( $post['ID'] ) : 0;
 
 		if ( isset( $rtmedia_thumbnail ) ) {

--- a/admin/rt-transcoder-functions.php
+++ b/admin/rt-transcoder-functions.php
@@ -165,7 +165,6 @@ function rt_media_get_video_thumbnail( $attachment_id ) {
 	}
 
 	return false;
-
 }
 
 /**
@@ -204,7 +203,6 @@ function rtt_get_media_url( $attachment_id, $media_type = 'mp4' ) {
 	}
 
 	return $final_file_url;
-
 }
 
 if ( ! function_exists( 'rtt_update_activity_after_thumb_set' ) ) {
@@ -460,7 +458,7 @@ function rtt_bp_get_activity_content( $content, $activity = null ) {
 			}
 			// If media is sent to the transcoder then show the message.
 			if ( is_file_being_transcoded( $media->media_id ) ) {
-				if ( current_user_can( 'administrator' ) && '1' === get_option( 'rtt_client_check_status_button', false ) ) {
+				if ( current_user_can( 'manage_options' ) && '1' === get_option( 'rtt_client_check_status_button', false ) ) {
 
 					$check_button_text = __( 'Check Status', 'transcoder' );
 
@@ -706,7 +704,6 @@ function rtt_add_status_columns_head( $defaults ) {
 
 	$defaults['convert_status'] = __( 'Transcode Status', 'transcoder' );
 	return $defaults;
-
 }
 
 add_filter( 'manage_media_columns', 'rtt_add_status_columns_head' );
@@ -765,7 +762,6 @@ function rtt_status_column_register_sortable( $columns ) {
 
 	$columns['convert_status'] = 'convert_status';
 	return $columns;
-
 }
 
 add_filter( 'manage_upload_sortable_columns', 'rtt_status_column_register_sortable' );
@@ -778,11 +774,11 @@ add_filter( 'manage_upload_sortable_columns', 'rtt_status_column_register_sortab
  */
 function rtt_enqueue_scripts() {
 
-	if ( current_user_can( 'administrator' ) ) {
+	if ( current_user_can( 'manage_options' ) ) {
 		wp_register_script( 'rt_transcoder_js', plugins_url( 'js/rt-transcoder.min.js', __FILE__ ), array(), RT_TRANSCODER_VERSION, false );
 
 		$translation_array = array(
-			'load_flag'      => current_user_can( 'administrator' ),
+			'load_flag'      => true,
 			'security_nonce' => esc_js( wp_create_nonce( 'check-transcoding-status-ajax-nonce' ) ),
 		);
 
@@ -859,7 +855,6 @@ function rtt_ajax_process_check_status_request() {
 	}
 
 	wp_die();
-
 }
 
 // Action added to handle check_status onclick request.
@@ -916,7 +911,7 @@ function rtt_add_transcoding_process_status_button_single_media_page( $rtmedia_i
 
 	if ( is_file_being_transcoded( $post_id ) ) {
 
-		if ( current_user_can( 'administrator' ) && '1' === get_option( 'rtt_client_check_status_button', false ) ) {
+		if ( current_user_can( 'manage_options' ) && '1' === get_option( 'rtt_client_check_status_button', false ) ) {
 			$message = sprintf(
 				'<div class="transcoding-in-progress"><button id="btn_check_status%1$s" class="btn_check_transcode_status" name="check_status_btn" data-value="%1$s">%2$s</button> <div class="transcode_status_box" id="span_status%1$s">%3$s</div></div>',
 				esc_attr( $post_id ),
@@ -988,7 +983,7 @@ add_filter( 'rtmedia_single_content_filter', 'rtt_filter_single_media_page_video
  * @param int    $attachment_id  ID of attachment.
  * @param string $autoformat     If true then generating thumbs only else trancode video.
  */
-function rtt_media_update_usage( $wp_metadata, $attachment_id, $autoformat = true ) {
+function rtt_media_update_usage( $wp_metadata, $attachment_id, $autoformat = true ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
 
 	$stored_key     = get_site_option( 'rt-transcoding-api-key' );
 	$transient_flag = get_transient( 'rtt_usage_update_flag' );
@@ -1018,7 +1013,7 @@ add_filter( 'wp_generate_attachment_metadata', 'rtt_media_update_usage', 10, 2 )
  *
  * @return string Filtered value if supports.
  */
-function get_server_var( $server_key, $filter_type = FILTER_SANITIZE_STRING ) {
+function get_server_var( $server_key, $filter_type = FILTER_SANITIZE_FULL_SPECIAL_CHARS ) {
 	$server_val = '';
 	if ( function_exists( 'filter_input' ) && filter_has_var( INPUT_SERVER, $server_key ) ) {
 		$server_val = transcoder_filter_input( INPUT_SERVER, $server_key, $filter_type );

--- a/admin/rt-transcoder-handler.php
+++ b/admin/rt-transcoder-handler.php
@@ -464,9 +464,9 @@ class RT_Transcoder_Handler {
 	 * @since   1.0.0
 	 */
 	public function save_api_key() {
-		$is_api_key_updated     = transcoder_filter_input( INPUT_GET, 'api-key-updated', FILTER_SANITIZE_STRING );
-		$is_invalid_license_key = transcoder_filter_input( INPUT_GET, 'invalid-license-key', FILTER_SANITIZE_STRING );
-		$is_localhost           = transcoder_filter_input( INPUT_GET, 'need-public-host', FILTER_SANITIZE_STRING );
+		$is_api_key_updated     = transcoder_filter_input( INPUT_GET, 'api-key-updated', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
+		$is_invalid_license_key = transcoder_filter_input( INPUT_GET, 'invalid-license-key', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
+		$is_localhost           = transcoder_filter_input( INPUT_GET, 'need-public-host', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 
 		if ( $is_api_key_updated ) {
 			if ( is_multisite() ) {
@@ -588,7 +588,7 @@ class RT_Transcoder_Handler {
 		<div class="updated">
 			<p>
 				<?php
-				$api_key_updated = transcoder_filter_input( INPUT_GET, 'api-key-updated', FILTER_SANITIZE_STRING );
+				$api_key_updated = transcoder_filter_input( INPUT_GET, 'api-key-updated', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 				printf(
 					wp_kses(
 						__( 'You have successfully subscribed.', 'transcoder' ),
@@ -1115,12 +1115,12 @@ class RT_Transcoder_Handler {
 	public function handle_callback() {
 		require_once ABSPATH . 'wp-admin/includes/image.php';
 
-		$job_id      = transcoder_filter_input( INPUT_POST, 'job_id', FILTER_SANITIZE_STRING );
-		$file_status = transcoder_filter_input( INPUT_POST, 'file_status', FILTER_SANITIZE_STRING );
-		$error_msg   = transcoder_filter_input( INPUT_POST, 'error_msg', FILTER_SANITIZE_STRING );
-		$job_for     = transcoder_filter_input( INPUT_POST, 'job_for', FILTER_SANITIZE_STRING );
-		$thumbnail   = transcoder_filter_input( INPUT_POST, 'thumbnail', FILTER_SANITIZE_STRING );
-		$format      = transcoder_filter_input( INPUT_POST, 'format', FILTER_SANITIZE_STRING );
+		$job_id      = transcoder_filter_input( INPUT_POST, 'job_id', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
+		$file_status = transcoder_filter_input( INPUT_POST, 'file_status', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
+		$error_msg   = transcoder_filter_input( INPUT_POST, 'error_msg', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
+		$job_for     = transcoder_filter_input( INPUT_POST, 'job_for', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
+		$thumbnail   = transcoder_filter_input( INPUT_POST, 'thumbnail', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
+		$format      = transcoder_filter_input( INPUT_POST, 'format', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 
 		if ( ! empty( $job_id ) && ! empty( $file_status ) && ( 'error' === $file_status ) ) {
 			$this->nofity_transcoding_failed( $job_id, $error_msg );
@@ -1183,7 +1183,7 @@ class RT_Transcoder_Handler {
 		} else {
 
 			// To check if request is sumitted from the WP Job Manager plugin ( https://wordpress.org/plugins/wp-job-manager/ ).
-			$job_manager_form = transcoder_filter_input( INPUT_POST, 'job_manager_form', FILTER_SANITIZE_STRING );
+			$job_manager_form = transcoder_filter_input( INPUT_POST, 'job_manager_form', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 
 			if ( isset( $job_id ) && ! empty( $job_id ) && class_exists( 'RTDBModel' ) && empty( $job_manager_form ) ) {
 
@@ -1281,7 +1281,7 @@ class RT_Transcoder_Handler {
 	 * @since 1.0
 	 */
 	public function enter_api_key() {
-		$apikey = transcoder_filter_input( INPUT_GET, 'apikey', FILTER_SANITIZE_STRING );
+		$apikey = transcoder_filter_input( INPUT_GET, 'apikey', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 		if ( ! empty( $apikey ) ) {
 			echo wp_json_encode( array( 'apikey' => $apikey ) );
 		} else {
@@ -1641,16 +1641,16 @@ class RT_Transcoder_Handler {
 		$post_var = $_POST; // phpcs:ignore WordPress.Security.NonceVerification.Missing
 
 		$filter_post_args = array(
-			'job_id'       => FILTER_SANITIZE_STRING,
-			'job_type'     => FILTER_SANITIZE_STRING,
-			'job_for'      => FILTER_SANITIZE_STRING,
-			'format'       => FILTER_SANITIZE_STRING,
+			'job_id'       => FILTER_SANITIZE_FULL_SPECIAL_CHARS,
+			'job_type'     => FILTER_SANITIZE_FULL_SPECIAL_CHARS,
+			'job_for'      => FILTER_SANITIZE_FULL_SPECIAL_CHARS,
+			'format'       => FILTER_SANITIZE_FULL_SPECIAL_CHARS,
 			'download_url' => FILTER_SANITIZE_URL,
-			'file_name'    => FILTER_SANITIZE_STRING,
+			'file_name'    => FILTER_SANITIZE_FULL_SPECIAL_CHARS,
 			'thumb_count'  => FILTER_SANITIZE_NUMBER_INT,
-			'status'       => FILTER_SANITIZE_STRING,
-			'error_msg'    => FILTER_SANITIZE_STRING,
-			'error_code'   => FILTER_SANITIZE_STRING,
+			'status'       => FILTER_SANITIZE_FULL_SPECIAL_CHARS,
+			'error_msg'    => FILTER_SANITIZE_FULL_SPECIAL_CHARS,
+			'error_code'   => FILTER_SANITIZE_FULL_SPECIAL_CHARS,
 		);
 
 		$post_array          = filter_input_array( INPUT_POST, $filter_post_args );

--- a/inc/helpers/custom-functions.php
+++ b/inc/helpers/custom-functions.php
@@ -38,7 +38,7 @@ function transcoder_filter_input( $type, $variable_name, $filter = FILTER_DEFAUL
 		 * Code is not running on PHP Cli and we are in clear.
 		 * Use the PHP method and bail out.
 		 */
-		if ( ! empty( $sanitized_variable ) && FILTER_SANITIZE_STRING === $filter ) {
+		if ( ! empty( $sanitized_variable ) && FILTER_SANITIZE_FULL_SPECIAL_CHARS === $filter ) {
 			$sanitized_variable = sanitize_text_field( $sanitized_variable );
 		}
 


### PR DESCRIPTION
##  Fix PHP@8.1 deprecation errors and enhance security checks

### Fix PHP@8.1 deprecation errors
- Replace `FILTER_SANITIZE_STRING` with `FILTER_SANITIZE_FULL_SPECIAL_CHARS`.

### Enhance security checks
- Change escaping functions `esc_attr` to `esc_html` and vise-versa on required places.
- Replace `current_user_can( 'administrator' )` with `current_user_can( 'manage_options' )` because there is not such capability with the name `administrator`.

### Related issues
- #275 