### PR TITLE
Fix js script dependency error

### DIFF
--- a/admin/rt-transcoder-functions.php
+++ b/admin/rt-transcoder-functions.php
@@ -811,7 +811,7 @@ function rtt_enqueue_frontend_scripts() {
 	$file_to_use = 'public-assets/js/build/transcoder.min.js';
 
 	$file = path_join( RT_TRANSCODER_PATH, $file_to_use );
-	if ( file_exists( $file ) ) {
+	if ( file_exists( $file ) && class_exists( 'RTMedia' ) ) {
 		wp_enqueue_script( 'rt-transcoder-front-js', RT_TRANSCODER_URL . $file_to_use, array( 'jquery', 'rtmedia-backbone' ), filemtime( $file ), true );
 
 		$rest_url_prefix = get_site_url() . '/' . rest_get_url_prefix();


### PR DESCRIPTION
## Fix js script dependency error

### Changes
- Add a check to enqueue a script only when the `rtMedia` plugin is activated.
- `class_exists( 'RTMedia' )` is used to check this.
- This script is making changes to rtMedia UI components. So it is not required when rtMedia is deactivated/not installed.