### PR TITLE
Allowed video files with 3g2 extension.

### DIFF
--- a/admin/rt-transcoder-handler.php
+++ b/admin/rt-transcoder-handler.php
@@ -74,7 +74,7 @@ class RT_Transcoder_Handler {
 	 * @access   public
 	 * @var      string    $video_extensions    Video extensions with comma separated.
 	 */
-	public $video_extensions = ',mov,m4v,m2v,avi,mpg,flv,wmv,mkv,webm,ogv,mxf,asf,vob,mts,qt,mpeg,x-msvideo,3gp';
+	public $video_extensions = ',mov,m4v,m2v,avi,mpg,flv,wmv,mkv,webm,ogv,mxf,asf,vob,mts,qt,mpeg,x-msvideo,3gp,3g2';
 
 	/**
 	 * Audio extensions with comma separated.


### PR DESCRIPTION
## What This Does
It allows files with 3g2 extensions.
https://github.com/rtCamp/transcoder/issues/248

## How To Test
Upload media in wp-admin-> media and check if the file gets transcoded or not.

