### PR TITLE
Add changelog and upgrade notice for v1.3.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Read [Documentation](https://rtmedia.io/docs/transcoder/?utm_source=readme&utm_m
 
 * ENHANCEMENTS
 
- * Changed the admin notice for users.
+ * Changed the admin notice for users on transcoder tabs and main dashboard page.
  * Removed the subscription reminder notice shown when no API key is configured.
 
 #### 1.3.6 [February 27, 2024] ####

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Transcoding services for ANY WordPress website. Convert audio/video files of any
  <img src="https://rtmedia.io/wp-content/uploads/2016/08/trancoder-banner-01.png" alt="Transcoder Banner"/>
 </p>
 
-* **Contributors:** [rtcamp](http://profiles.wordpress.org/rtcamp), [mangeshp](http://profiles.wordpress.org/mangeshp), [chandrapatel](http://profiles.wordpress.org/chandrapatel), [manishsongirkar36](http://profiles.wordpress.org/manishsongirkar36), [bhargavbhandari90](http://profiles.wordpress.org/bhargavbhandari90), [kiranpotphode](http://profiles.wordpress.org/kiranpotphode), [thrijith](http://profiles.wordpress.org/thrijith), [devikvekariya](http://profiles.wordpress.org/devikvekariya), [sagarnasit](http://profiles.wordpress.org/sagarnasit), [sudhiryadav](http://profiles.wordpress.org/sudhiryadav), [sid177](https://profiles.wordpress.org/sid177/), [pooja1210](https://profiles.wordpress.org/pooja1210/), [vaishu.agola27](https://profiles.wordpress.org/vaishuagola27/), [ravatparmar](https://profiles.wordpress.org/ravatparmar/), [tremidkhar](https://profiles.wordpress.org/tremidkhar/), [utsavladani](https://profiles.wordpress.org/utsavladani/), [vishalkakadiya](https://profiles.wordpress.org/vishalkakadiya/), [pavanpatil1](https://profiles.wordpress.org/pavanpatil1/), [akrocks](https://profiles.wordpress.org/akrocks/), [hrithikd](https://profiles.wordpress.org/hrithikd/), [sohampate1](https://profiles.wordpress.org/sohampate1/)
+* **Contributors:** [rtcamp](http://profiles.wordpress.org/rtcamp), [mangeshp](http://profiles.wordpress.org/mangeshp), [chandrapatel](http://profiles.wordpress.org/chandrapatel), [manishsongirkar36](http://profiles.wordpress.org/manishsongirkar36), [bhargavbhandari90](http://profiles.wordpress.org/bhargavbhandari90), [kiranpotphode](http://profiles.wordpress.org/kiranpotphode), [thrijith](http://profiles.wordpress.org/thrijith), [devikvekariya](http://profiles.wordpress.org/devikvekariya), [sagarnasit](http://profiles.wordpress.org/sagarnasit), [sudhiryadav](http://profiles.wordpress.org/sudhiryadav), [sid177](https://profiles.wordpress.org/sid177/), [pooja1210](https://profiles.wordpress.org/pooja1210/), [vaishu.agola27](https://profiles.wordpress.org/vaishuagola27/), [ravatparmar](https://profiles.wordpress.org/ravatparmar/), [tremidkhar](https://profiles.wordpress.org/tremidkhar/), [utsavladani](https://profiles.wordpress.org/utsavladani/), [vishalkakadiya](https://profiles.wordpress.org/vishalkakadiya/), [pavanpatil1](https://profiles.wordpress.org/pavanpatil1/), [akrocks](https://profiles.wordpress.org/akrocks/), [hrithikd](https://profiles.wordpress.org/hrithikd/), [sohampate1](https://profiles.wordpress.org/sohampate1/), [krishana79](https://profiles.wordpress.org/krishana79/)
 
 * **License:** [GPL v2 or later]( http://www.gnu.org/licenses/gpl-2.0.html)
 
@@ -65,6 +65,14 @@ Read [Documentation](https://rtmedia.io/docs/transcoder/?utm_source=readme&utm_m
 1. Transcoder Settings
 
 ## Changelog ##
+
+#### 1.3.7 [April 18, 2025] ####
+
+* ENHANCEMENTS
+
+ * Changed the admin notice for users.
+ * Removed the subscription reminder notice shown when no API key is configured.
+
 #### 1.3.6 [February 27, 2024] ####
 
 * FIXED

--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 === Transcoder ===
-Contributors: rtcamp, mangeshp, chandrapatel, manishsongirkar36, bhargavbhandari90, kiranpotphode, thrijith, devikvekariya, sagarnasit, sudhiryadav, sid177, pooja1210, vaishu.agola27, ravatparmar, tremidkhar, kapilpaul, utsavladani, vishalkakadiya, pavanpatil1, akrocks, hrithikd, sohampate1
+Contributors: rtcamp, mangeshp, chandrapatel, manishsongirkar36, bhargavbhandari90, kiranpotphode, thrijith, devikvekariya, sagarnasit, sudhiryadav, sid177, pooja1210, vaishu.agola27, ravatparmar, tremidkhar, kapilpaul, utsavladani, vishalkakadiya, pavanpatil1, akrocks, hrithikd, sohampate1, krishana79
 Tags: media, multimedia, audio, songs, music, video, ffmpeg, media-node, rtMedia, WordPress, kaltura, transcode, transcoder, encoding, encode
 Donate link: https://rtcamp.com/donate/
 Requires at least: 4.1
@@ -62,6 +62,14 @@ Read [Documentation](https://rtmedia.io/docs/transcoder/?utm_source=readme&utm_m
 1. Transcoder Settings
 
 == Changelog ==
+
+= 1.3.7 [April 18, 2025] =
+
+* ENHANCEMENTS
+
+ * Changed the admin notice for users.
+ * Removed the subscription reminder notice shown when no API key is configured.
+
 = 1.3.6 [February 27, 2024] =
 
 * FIXED
@@ -226,6 +234,10 @@ Read [Documentation](https://rtmedia.io/docs/transcoder/?utm_source=readme&utm_m
 Initial release
 
 == Upgrade Notice ==
+
+= 1.3.7 =
+Transcoder 1.3.7, with admin notice to install our new GoDAM plugin – with a powerful Digital Asset Management features along with video transcoding services.
+
 = 1.3.6 =
 Transcoder 1.3.6, with enhanced security.
 

--- a/readme.txt
+++ b/readme.txt
@@ -67,7 +67,7 @@ Read [Documentation](https://rtmedia.io/docs/transcoder/?utm_source=readme&utm_m
 
 * ENHANCEMENTS
 
- * Changed the admin notice for users.
+ * Changed the admin notice for users on transcoder tabs and main dashboard page.
  * Removed the subscription reminder notice shown when no API key is configured.
 
 = 1.3.6 [February 27, 2024] =

--- a/rt-transcoder.php
+++ b/rt-transcoder.php
@@ -3,7 +3,7 @@
  * Plugin Name: Transcoder
  * Plugin URI: https://rtmedia.io/transcoder/?utm_source=dashboard&utm_medium=plugin&utm_campaign=transcoder
  * Description: Audio & video transcoding services for ANY WordPress website. Allows you to convert audio/video files of any format to a web-friendly format (mp3/mp4).
- * Version: 1.3.6
+ * Version: 1.3.7
  * Text Domain: transcoder
  * Author: rtCamp
  * Author URI: https://rtcamp.com/?utm_source=dashboard&utm_medium=plugin&utm_campaign=transcoder
@@ -39,7 +39,7 @@ if ( ! defined( 'RT_TRANSCODER_VERSION' ) ) {
 	/**
 	 * The version of the plugin
 	 */
-	define( 'RT_TRANSCODER_VERSION', '1.3.6' );
+	define( 'RT_TRANSCODER_VERSION', '1.3.7' );
 }
 
 if ( ! defined( 'RT_TRANSCODER_NO_MAIL' ) && defined( 'VIP_GO_APP_ENVIRONMENT' ) ) {


### PR DESCRIPTION
## Changelog
 * Changed the admin notice for users on transcoder tabs and main dashboard page.
 * Removed the subscription reminder notice shown when no API key is configured.