### PR TITLE
Fix: rtMedia Shortcode [ Develop ]

### DIFF
--- a/admin/rt-transcoder-functions.php
+++ b/admin/rt-transcoder-functions.php
@@ -68,6 +68,10 @@ function rt_media_shortcode( $attrs, $content = '' ) {
 		// Generate a poster thumbnail for the video.
 		$poster = rt_media_get_video_thumbnail( $attachment_id );
 
+		if ( empty( $media_url ) ) {
+			return '<p>' . esc_html__( 'Media file unavailable.', 'transcoder' ) . '</p>';
+		}
+
 		// Force shortcode to use validated `src` + `poster`.
 		$attrs['src']    = $media_url;
 		$attrs['poster'] = $poster;
@@ -94,6 +98,13 @@ function rt_media_shortcode( $attrs, $content = '' ) {
 
 		// Resolve audio URL (prefer transcoded mp3).
 		$media_url = rtt_get_media_url( $attachment_id, 'mp3' );
+
+
+		// Graceful fallback: if media URL cannot be resolved (e.g. missing file),
+		// show a friendly message instead of rendering a broken player.
+		if ( empty( $media_url ) ) {
+			return '<p>' . esc_html__( 'Media file unavailable.', 'transcoder' ) . '</p>';
+		}
 
 		// Force valid `src` attribute.
 		$attrs['src'] = $media_url;


### PR DESCRIPTION
## Summary
This PR hardens the `[rt_media]` shortcode against potential XSS and attribute injection vulnerabilities, and improves error handling for invalid or missing media.

## Changes
### Security
- Validated and sanitized all shortcode attributes before output.
- Restricted allowed attributes (`src`, `poster`, etc.) for video/audio to prevent arbitrary attribute injection.
- Escaped all attribute values (`esc_url` for URLs, `esc_attr` for others).
- Enforced `absint()` on `attachment_id` to prevent non-integer input.

### Error Handling / UX
- Added fallback message when:
  - Invalid or missing `attachment_id` is passed.
  - Media type is not supported.
  - Media file URL cannot be resolved (e.g., file deleted).
- Prevents rendering broken `<video>` / `<audio>` players.

## Why
- Fixes possible XSS when unsanitized attributes were injected into shortcode output.
- Makes shortcode safer to use across all roles (e.g., contributors submitting posts).
- Provides a clearer user experience by showing friendly messages instead of silent failures or broken players.

## Testing
1. Add `[rt_media attachment_id="valid_id"]` → should render media correctly.  
2. Add `[rt_media attachment_id="invalid_id"]` → should show **"Invalid attachment ID."** message.  
3. Add `[rt_media attachment_id="valid_id"]` where file is missing → should show **"Media file unavailable."**  
4. Try injecting malicious attributes in the shortcode → should be sanitized and not execute.
